### PR TITLE
fix hash check problem in todesk

### DIFF
--- a/bucket/todesk.json
+++ b/bucket/todesk.json
@@ -4,7 +4,7 @@
   "version": "4.7.4.3",
   "license": "Proprietary",
   "url": "https://dl.todesk.com/windows/ToDesk_Setup.exe#/dl.7z",
-  "hash": "35ef5fa64be5bc9e3e6418f959421ef6d858c68c3352ea4277c66171a6c6d1b3",
+  "hash": "fb3fd77cbb36aba970e2b419b826c8f3ad6fe629b6ee9dd87896971bec1612ce",
   "pre_install": [
     "if (!(Test-Path \"$persist_dir\\config.ini\")) {",
     "    New-Item -Force -Path \"$persist_dir\\config.ini\" -ItemType File -Value \"[ConfigInfo]`nautoStart=0\" | Out-Null",


### PR DESCRIPTION
the rebot did not fix the problem with the hash code

logs like:

Installing 'todesk' (4.7.4.3) [64bit] from 'main' bucket
ToDesk_Setup.exe (96.5 MB) [==================================================================================] 100%
Checking hash of ToDesk_Setup.exe ... ERROR Hash check failed!
App: main/todesk
URL: https://dl.todesk.com/windows/ToDesk_Setup.exe#/dl.7z
First bytes: 4D 5A 90 00 03 00 00 00
Expected: 22a5f51164cf2c6fdefd8823f09c68593ca7093e3866b3db04432aef64463a19
Actual: fb3fd77cbb36aba970e2b419b826c8f3ad6fe629b6ee9dd87896971bec1612ce

Please try again or create a new issue by using the following link and paste your console output:
https://mirror.ghproxy.com/github.com/lzwme/scoop-proxy-cn/issues/new?title=todesk%404.7.4.3%3a+hash+check+failed

the actual hash code might be fb3fd77cbb36aba970e2b419b826c8f3ad6fe629b6ee9dd87896971bec1612ce, and this commit might fix the problem

we can use `-s` to install todesk successfully, but I think we should solve the problem in the end

