### PR TITLE
Update notepad--.json

### DIFF
--- a/bucket/notepad--.json
+++ b/bucket/notepad--.json
@@ -10,7 +10,6 @@
       "hash": "046ef631efcda2a66e69fde5471d777a535b7808954e6bd168fce5cbefa8039e"
     }
   },
-  "extract_dir": "Notepad--v2.20.1-win10-portable",
   "shortcuts": [
     [
       "Notepad--.exe",


### PR DESCRIPTION
新版本notepad--已经到3.x版本不再需要旧版本的信息，旧版本内容会导致新版本安装出错，相关案例 #101 